### PR TITLE
Changed YouTube link to Vimeo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Transcript of <http://www.youtube.com/watch?v=VShmtsLhkQg>.
+Transcript of <https://vimeo.com/89936101>.
 
 Full runtime: approximately 36m09s
 


### PR DESCRIPTION
The YouTube Link is no longer valid, so I replaced with a mirror on Vimeo.
